### PR TITLE
Return Exit Code From Executed Command

### DIFF
--- a/wait_for_it/wait_for_it.py
+++ b/wait_for_it/wait_for_it.py
@@ -50,7 +50,8 @@ def cli(service, quiet, timeout, commands):
         connect(s, timeout)
 
     if len(commands):
-        subprocess.run(commands)
+        result = subprocess.run(commands)
+        sys.exit(result.returncode)
 
 
 def connect(service, timeout):


### PR DESCRIPTION
Thanks for creating this. I've been using the wait-for-it.sh bash script but I realized I needed something to handle multiple services.

This is my attempt at giving back to the community. I've taken a stab at fixing issue #3 where the request was to return the exit code after executing the command.
