### PR TITLE
Make GitHub Dependabot keep our GitHub Actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    commit-message:
+      include: "scope"
+      prefix: "Actions"
+    directory: "/"
+    labels:
+      - "enhancement"
+    reviewers:
+      - "clarketm"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Hi!

I noticed at
https://github.com/clarketm/wait-for-it/blob/0632f8d7de5049b305bda6a685e28350460ef1d8/.github/workflows/python-package.yaml#L13
that we're not using the latest version of [action `setup-python`](https://github.com/actions/setup-python) here. Rather than opening a pull request to bump the version manually, I would rather introduce my friend [GitHub Dependabot](https://github.com/dependabot) who can do bumps not just today but in the future. I [started using the bot at jawanndenn yesterday](https://github.com/hartwork/jawanndenn/commit/966bbd9455101a55b8f03d73384096fe666b7d50) and I'm rather happy with [the results](https://github.com/hartwork/jawanndenn/pull/47) so far. All it takes is this YAML file. You'll see a tab for Dependabot at https://github.com/clarketm/wait-for-it/network/dependencies as a result.

What do you think?