### PR TITLE
asyncio + parallel mode (fixes #6)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     python_requires=">=3.6",
     py_modules=["wait_for_it"],
     install_requires=["click"],
-    extras_require={"dev": ["black", "click", "flake8", "pytest", "pytest-cov", "twine"]},
+    extras_require={"dev": ["black", "click", "flake8", "parameterized", "pytest", "pytest-cov", "twine"]},
     entry_points={"console_scripts": ["wait-for-it=wait_for_it.wait_for_it:cli"]},
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/wait_for_it/test_wait_for_it.py
+++ b/wait_for_it/test_wait_for_it.py
@@ -61,21 +61,34 @@ class CliTest(TestCase):
         assert "Usage:" in result.output
         assert result.exit_code == 0
 
-    def test_service_available(self):
+    @parameterized.expand([("parallel", ["-p"]), ("serial", [])])
+    def test_service_available(self, _label, extra_argv):
         server = _start_server_thread()
         try:
             result = self._runner.invoke(
-                cli, ["-t1", "-s", f"{server.host}:{server.port}"]
+                cli,
+                [
+                    "-t1",
+                    "-s",
+                    f"{server.host}:{server.port}",
+                    "-s",
+                    f"{server.host}:{server.port}",
+                ]
+                + extra_argv,
             )
             assert " is available after " in result.output
             assert result.exit_code == 0
         finally:
             server.stop()
 
-    def test_service_unavailable(self):
+    @parameterized.expand([("parallel", ["-p"]), ("serial", [])])
+    def test_service_unavailable(self, _label, extra_argv):
         host, port, sock = _occupy_free_tcp_port()
         try:
-            result = self._runner.invoke(cli, ["-t1", "-s", f"{host}:{port}"])
+            result = self._runner.invoke(
+                cli,
+                ["-t1", "-s", f"{host}:{port}", "-s", f"{host}:{port}"] + extra_argv,
+            )
             assert "timeout occurred" in result.output
             assert result.exit_code == 1
         finally:

--- a/wait_for_it/test_wait_for_it.py
+++ b/wait_for_it/test_wait_for_it.py
@@ -5,7 +5,8 @@ from threading import Event, Thread
 from unittest import TestCase
 
 from click.testing import CliRunner
-from .wait_for_it import cli
+from parameterized import parameterized
+from .wait_for_it import cli, _determine_host_and_port_for
 
 _ANY_FREE_PORT = 0
 
@@ -79,3 +80,20 @@ class CliTest(TestCase):
             assert result.exit_code == 1
         finally:
             sock.close()
+
+
+class DetermineHostAndPortForTest(TestCase):
+    @parameterized.expand(
+        [
+            ("domain.ext", 80),
+            ("domain.ext:123", 123),
+            ("http://domain.ext", 80),
+            ("http://domain.ext/path/", 80),
+            ("https://domain.ext", 443),
+            ("https://domain.ext/path/", 443),
+        ]
+    )
+    def test_supportec(self, service, expected_port):
+        actual_host, actual_port = _determine_host_and_port_for(service)
+        assert actual_host == "domain.ext"
+        assert actual_port == expected_port

--- a/wait_for_it/test_wait_for_it.py
+++ b/wait_for_it/test_wait_for_it.py
@@ -1,11 +1,17 @@
 """wait_for_it cli test module"""
+from unittest import TestCase
+
 from click.testing import CliRunner
 from .wait_for_it import cli
 
 
-# https://click.palletsprojects.com/en/7.x/testing/
-def test_cli_help():
-    runner = CliRunner()
-    result = runner.invoke(cli, ["--help"])
-    assert 'Usage:' in result.output
-    assert result.exit_code == 0
+class CliTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # https://click.palletsprojects.com/en/7.x/testing/
+        cls._runner = CliRunner()
+
+    def test_help(self):
+        result = self._runner.invoke(cli, ["--help"])
+        assert 'Usage:' in result.output
+        assert result.exit_code == 0

--- a/wait_for_it/test_wait_for_it.py
+++ b/wait_for_it/test_wait_for_it.py
@@ -7,4 +7,5 @@ from .wait_for_it import cli
 def test_cli_help():
     runner = CliRunner()
     result = runner.invoke(cli, ["--help"])
+    assert 'Usage:' in result.output
     assert result.exit_code == 0

--- a/wait_for_it/test_wait_for_it.py
+++ b/wait_for_it/test_wait_for_it.py
@@ -1,6 +1,6 @@
 """wait_for_it cli test module"""
 from click.testing import CliRunner
-from wait_for_it.wait_for_it import cli
+from .wait_for_it import cli
 
 
 # https://click.palletsprojects.com/en/7.x/testing/

--- a/wait_for_it/test_wait_for_it.py
+++ b/wait_for_it/test_wait_for_it.py
@@ -1,8 +1,52 @@
 """wait_for_it cli test module"""
+import socket
+import socketserver
+from threading import Event, Thread
 from unittest import TestCase
 
 from click.testing import CliRunner
 from .wait_for_it import cli
+
+_ANY_FREE_PORT = 0
+
+
+class _DummyTcpServerThread(Thread):
+    """
+    A TCP server as a Thread that takes any free port, accepts connections,
+    but doesn't do any meaningful traffic.
+    """
+
+    class _DummyHandler(socketserver.BaseRequestHandler):
+        pass
+
+    def __init__(self):
+        super().__init__()
+        self.started = Event()
+
+    def run(self):
+        with socketserver.TCPServer(
+            ("127.0.0.1", _ANY_FREE_PORT), self._DummyHandler
+        ) as self._server:
+            self.host, self.port = self._server.server_address
+            self.started.set()
+            self._server.serve_forever()
+
+    def stop(self):
+        self._server.shutdown()
+
+
+def _start_server_thread():
+    server = _DummyTcpServerThread()
+    server.start()
+    server.started.wait()
+    return server
+
+
+def _occupy_free_tcp_port():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", _ANY_FREE_PORT))
+    host, port = sock.getsockname()
+    return host, port, sock
 
 
 class CliTest(TestCase):
@@ -13,5 +57,25 @@ class CliTest(TestCase):
 
     def test_help(self):
         result = self._runner.invoke(cli, ["--help"])
-        assert 'Usage:' in result.output
+        assert "Usage:" in result.output
         assert result.exit_code == 0
+
+    def test_service_available(self):
+        server = _start_server_thread()
+        try:
+            result = self._runner.invoke(
+                cli, ["-t1", "-s", f"{server.host}:{server.port}"]
+            )
+            assert " is available after " in result.output
+            assert result.exit_code == 0
+        finally:
+            server.stop()
+
+    def test_service_unavailable(self):
+        host, port, sock = _occupy_free_tcp_port()
+        try:
+            result = self._runner.invoke(cli, ["-t1", "-s", f"{host}:{port}"])
+            assert "timeout occurred" in result.output
+            assert result.exit_code == 1
+        finally:
+            sock.close()

--- a/wait_for_it/wait_for_it.py
+++ b/wait_for_it/wait_for_it.py
@@ -113,7 +113,8 @@ def connect(service, timeout):
 
     asyncio.run(_wait_until_available(host, port))
 
-    signal.alarm(0)  # disarm sys-exit timer
+    if timeout > 0:
+        signal.alarm(0)  # disarm sys-exit timer
 
     reporter.on_success()
 

--- a/wait_for_it/wait_for_it.py
+++ b/wait_for_it/wait_for_it.py
@@ -80,6 +80,7 @@ class _ConnectionJobReporter:
         self._friendly_name = f"{host}:{port}"
         self._timeout = timeout
         self._started_at = None
+        self.job_successful = None
 
     def on_before_start(self):
         if self._timeout:
@@ -91,6 +92,7 @@ class _ConnectionJobReporter:
     def on_success(self):
         seconds = round(time.time() - self._started_at)
         print(f"{self._friendly_name} is available after {seconds} seconds")
+        self.job_successful = True
 
     def on_timeout(self):
         print(

--- a/wait_for_it/wait_for_it.py
+++ b/wait_for_it/wait_for_it.py
@@ -120,12 +120,10 @@ def connect(service, timeout):
     host, port = _determine_host_and_port_for(service)
     reporter = _ConnectionJobReporter(host, port, timeout)
 
-    reporter.on_before_start()
-
     with _exit_on_timeout(timeout, on_exit=reporter.on_timeout):
+        reporter.on_before_start()
         asyncio.run(_wait_until_available(host, port))
-
-    reporter.on_success()
+        reporter.on_success()
 
 
 if __name__ == "__main__":

--- a/wait_for_it/wait_for_it.py
+++ b/wait_for_it/wait_for_it.py
@@ -34,6 +34,12 @@ async def _wait_until_available(host, port):
         await asyncio.sleep(1)
 
 
+async def _wait_until_available_and_report(reporter, host, port):
+    reporter.on_before_start()
+    await _wait_until_available(host, port)
+    reporter.on_success()
+
+
 @click.command()
 @click.help_option("-h", "--help")
 @click.version_option(__version__, "-v", "--version", message="Version %(version)s")
@@ -121,9 +127,7 @@ def connect(service, timeout):
     reporter = _ConnectionJobReporter(host, port, timeout)
 
     with _exit_on_timeout(timeout, on_exit=reporter.on_timeout):
-        reporter.on_before_start()
-        asyncio.run(_wait_until_available(host, port))
-        reporter.on_success()
+        asyncio.run(_wait_until_available_and_report(reporter, host, port))
 
 
 if __name__ == "__main__":

--- a/wait_for_it/wait_for_it.py
+++ b/wait_for_it/wait_for_it.py
@@ -73,8 +73,7 @@ def cli(service, quiet, timeout, commands):
     if quiet:
         sys.stdout = open(os.devnull, "w")
 
-    for s in service:
-        connect(s, timeout)
+    _connect_all_serial(service, timeout)
 
     if len(commands):
         result = subprocess.run(commands)
@@ -120,6 +119,11 @@ def _exit_on_timeout(timeout, on_exit):
 
     if timeout > 0:
         signal.alarm(0)  # disarm sys-exit timer
+
+
+def _connect_all_serial(services, timeout):
+    for service in services:
+        connect(service, timeout)
 
 
 def connect(service, timeout):


### PR DESCRIPTION
Hi Travis,

this sits on top of PR #13 because it needs the tests to be able to extend them; happy to rebase on `master` after merge of #13 as needed.

So this fixes #6 by first leveraging asyncio and then introducing parallel mode with minimal code duplication, optional and off-by-default. Interestingly, user experience improves significantly in parallel mode, I find:


#### Serial mode

```console
# time wait-for-it -t 2 -s 127.0.0.1:1 -s 127.0.0.1:2 -s google.com -s amazon.com
waiting 2 seconds for 127.0.0.1:1
timeout occurred after waiting 2 seconds for 127.0.0.1:1

real    0m2.140s
user    0m0.128s
sys     0m0.014s

```


#### Parallel mode

```console
# time wait-for-it -p -t 2 -s 127.0.0.1:1 -s 127.0.0.1:2 -s google.com -s amazon.com
waiting 2 seconds for 127.0.0.1:1
waiting 2 seconds for 127.0.0.1:2
waiting 2 seconds for google.com:80
waiting 2 seconds for amazon.com:80
google.com:80 is available after 0 seconds
amazon.com:80 is available after 0 seconds
timeout occurred after waiting 2 seconds for 127.0.0.1:1
timeout occurred after waiting 2 seconds for 127.0.0.1:2

real    0m2.133s
user    0m0.131s
sys     0m0.017s
```


So parallel mode is not only a speed-up in case of multiple services but also provides more usefuly information for when one or more services are not available.

Looking forward to your review, best, Sebastian
