### PR TITLE
Polish reporting output

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ $ wait-for-it \
 ```
 
 ```text
-waiting 15 seconds for www.google.com:80
-www.google.com:80 is available after 0 seconds
+[*] Waiting 15 seconds for www.google.com:80
+[+] www.google.com:80 is available after 0 seconds
 google is up
 ```
 
@@ -70,8 +70,8 @@ $ wait-for-it \
 ```
 
 ```text
-waiting for www.google.com:80 without a timeout
-www.google.com:80 is available after 0 seconds
+[*] Waiting for www.google.com:80 without a timeout
+[+] www.google.com:80 is available after 0 seconds
 google is up
 ```
 
@@ -86,12 +86,12 @@ $ wait-for-it \
 ```
 
 ```text
-waiting 15 seconds for www.google.com:80
-www.google.com:80 is available after 0 seconds
-waiting 15 seconds for www.bing.com:80
-www.bing.com:80 is available after 0 seconds
-waiting 15 seconds for www.duckduckgo.com:80
-www.duckduckgo.com:80 is available after 0 seconds
+[*] Waiting 15 seconds for www.google.com:80
+[+] www.google.com:80 is available after 0 seconds
+[*] Waiting 15 seconds for www.bing.com:80
+[+] www.bing.com:80 is available after 0 seconds
+[*] Waiting 15 seconds for www.duckduckgo.com:80
+[+] www.duckduckgo.com:80 is available after 0 seconds
 google, bing, and duckduckgo are up
 ```
 
@@ -107,12 +107,12 @@ $ wait-for-it \
 ```
 
 ```text
-waiting 15 seconds for www.bing.com:80
-waiting 15 seconds for www.duckduckgo.com:80
-waiting 15 seconds for www.google.com:80
-www.bing.com:80 is available after 0 seconds
-www.duckduckgo.com:80 is available after 0 seconds
-www.google.com:80 is available after 0 seconds
+[*] Waiting 15 seconds for www.bing.com:80
+[*] Waiting 15 seconds for www.duckduckgo.com:80
+[*] Waiting 15 seconds for www.google.com:80
+[+] www.bing.com:80 is available after 0 seconds
+[+] www.duckduckgo.com:80 is available after 0 seconds
+[+] www.google.com:80 is available after 0 seconds
 google, bing, and duckduckgo are up
 ```
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -63,8 +63,8 @@ $ wait-for-it \
 ```
 
 ```text
-waiting 15 seconds for www.google.com:80
-www.google.com:80 is available after 0 seconds
+[*] Waiting 15 seconds for www.google.com:80
+[+] www.google.com:80 is available after 0 seconds
 google is up
 ```
 
@@ -94,12 +94,12 @@ $ wait-for-it \
 ```
 
 ```text
-waiting 15 seconds for www.google.com:80
-www.google.com:80 is available after 0 seconds
-waiting 15 seconds for www.bing.com:80
-www.bing.com:80 is available after 0 seconds
-waiting 15 seconds for www.duckduckgo.com:80
-www.duckduckgo.com:80 is available after 0 seconds
+[*] Waiting 15 seconds for www.google.com:80
+[+] www.google.com:80 is available after 0 seconds
+[*] Waiting 15 seconds for www.bing.com:80
+[+] www.bing.com:80 is available after 0 seconds
+[*] Waiting 15 seconds for www.duckduckgo.com:80
+[+] www.duckduckgo.com:80 is available after 0 seconds
 google, bing, and duckduckgo are up
 ```
 
@@ -115,12 +115,12 @@ $ wait-for-it \
 ```
 
 ```text
-waiting 15 seconds for www.bing.com:80
-waiting 15 seconds for www.duckduckgo.com:80
-waiting 15 seconds for www.google.com:80
-www.bing.com:80 is available after 0 seconds
-www.duckduckgo.com:80 is available after 0 seconds
-www.google.com:80 is available after 0 seconds
+[*] Waiting 15 seconds for www.bing.com:80
+[*] Waiting 15 seconds for www.duckduckgo.com:80
+[*] Waiting 15 seconds for www.google.com:80
+[+] www.bing.com:80 is available after 0 seconds
+[+] www.duckduckgo.com:80 is available after 0 seconds
+[+] www.google.com:80 is available after 0 seconds
 google, bing, and duckduckgo are up
 ```
 

--- a/wait_for_it/test_wait_for_it.py
+++ b/wait_for_it/test_wait_for_it.py
@@ -104,7 +104,7 @@ class CliTest(TestCase):
                 cli,
                 ["-t1", "-s", f"{host}:{port}", "-s", f"{host}:{port}"] + extra_argv,
             )
-            assert result.output.count("timeout occurred") == expected_report_count
+            assert result.output.count("Timeout occurred") == expected_report_count
             assert result.exit_code == 1
         finally:
             sock.close()

--- a/wait_for_it/wait_for_it.py
+++ b/wait_for_it/wait_for_it.py
@@ -103,6 +103,10 @@ def cli(service, quiet, parallel, timeout, commands):
 
 
 class _ConnectionJobReporter:
+    _SUCCESS = "[+] "
+    _FAILURE = "[-] "
+    _NEUTRAL = "[*] "
+
     def __init__(self, host, port, timeout):
         self._friendly_name = f"{host}:{port}"
         self._timeout = timeout
@@ -111,19 +115,24 @@ class _ConnectionJobReporter:
 
     def on_before_start(self):
         if self._timeout:
-            print(f"waiting {self._timeout} seconds for {self._friendly_name}")
+            print(
+                f"{self._NEUTRAL}Waiting {self._timeout} seconds for {self._friendly_name}"
+            )
         else:
-            print(f"waiting for {self._friendly_name} without a timeout")
+            print(f"{self._NEUTRAL}Waiting for {self._friendly_name} without a timeout")
         self._started_at = time.time()
 
     def on_success(self):
         seconds = round(time.time() - self._started_at)
-        print(f"{self._friendly_name} is available after {seconds} seconds")
+        print(
+            f"{self._SUCCESS}{self._friendly_name} is available after {seconds} seconds"
+        )
         self.job_successful = True
 
     def on_timeout(self):
         print(
-            f"timeout occurred after waiting {self._timeout} seconds for {self._friendly_name}"
+            f"{self._FAILURE}Timeout occurred after waiting {self._timeout} seconds"
+            f" for {self._friendly_name}"
         )
 
 


### PR DESCRIPTION
Just an idea, I've seen prefixes like that elsewhere — what do you think?

```
# wait-for-it -p -t 3 -s 127.0.0.1:1 -s 127.0.0.1:2 -s google.com -s amazon.com
[*] Waiting 3 seconds for 127.0.0.1:2
[*] Waiting 3 seconds for google.com:80
[*] Waiting 3 seconds for amazon.com:80
[*] Waiting 3 seconds for 127.0.0.1:1
[+] google.com:80 is available after 0 seconds
[+] amazon.com:80 is available after 0 seconds
[-] Timeout occurred after waiting 3 seconds for 127.0.0.1:1
[-] Timeout occurred after waiting 3 seconds for 127.0.0.1:2
```

I can take care of updating the demo output in docs, if you like the idea.

PS: Sits on top of #22 only to avoid merge conflicts with regard to tests.