### PR TITLE
Ignore OSError (and TypeError) on asyncio connection, fix #25

### DIFF
--- a/wait_for_it/test_wait_for_it.py
+++ b/wait_for_it/test_wait_for_it.py
@@ -51,10 +51,10 @@ def _start_server_thread():
     return server
 
 
-def _occupy_free_tcp_port():
+def _occupy_free_tcp_port(host):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.bind(("127.0.0.1", _ANY_FREE_PORT))
-    host, port = sock.getsockname()
+    sock.bind((host, _ANY_FREE_PORT))
+    _, port = sock.getsockname()
     return host, port, sock
 
 
@@ -100,9 +100,18 @@ class CliTest(TestCase):
         finally:
             server.stop()
 
-    @parameterized.expand([("parallel", ["-p"], 2), ("serial", [], 1)])
-    def test_service_unavailable(self, _label, extra_argv, expected_report_count):
-        host, port, sock = _occupy_free_tcp_port()
+    @parameterized.expand(
+        [
+            ("parallel", ["-p"], 2, "127.0.0.1"),
+            ("parallel", ["-p"], 2, "0.0.0.0"),
+            ("parallel", ["-p"], 2, "localhost"),
+            ("serial", [], 1, "127.0.0.1"),
+            ("serial", [], 1, "0.0.0.0"),
+            ("serial", [], 1, "localhost"),
+        ]
+    )
+    def test_service_unavailable(self, _label, extra_argv, expected_report_count, host):
+        _, port, sock = _occupy_free_tcp_port(host)
         try:
             result = self._runner.invoke(
                 cli,

--- a/wait_for_it/wait_for_it.py
+++ b/wait_for_it/wait_for_it.py
@@ -54,7 +54,7 @@ async def _wait_until_available(host, port):
             if sys.version_info[:2] >= (3, 7):
                 await writer.wait_closed()
             break
-        except (socket.gaierror, ConnectionError):
+        except (socket.gaierror, ConnectionError, OSError):
             pass
         await asyncio.sleep(1)
 

--- a/wait_for_it/wait_for_it.py
+++ b/wait_for_it/wait_for_it.py
@@ -54,7 +54,7 @@ async def _wait_until_available(host, port):
             if sys.version_info[:2] >= (3, 7):
                 await writer.wait_closed()
             break
-        except (socket.gaierror, ConnectionError, OSError):
+        except (socket.gaierror, ConnectionError, OSError, TypeError):
             pass
         await asyncio.sleep(1)
 


### PR DESCRIPTION
I bumped into this issue when preparing the release.
fix #25