### PR TITLE
Improve service syntax communication

### DIFF
--- a/wait_for_it/wait_for_it.py
+++ b/wait_for_it/wait_for_it.py
@@ -87,7 +87,7 @@ async def _wait_until_available_and_report(reporter, host, port):
     "--service",
     metavar="host:port",
     multiple=True,
-    help="Services to test, in the format host:port",
+    help="Services to test, in one of the formats 'host:port', '[v6addr]:port' or 'https://...'",
 )
 @click.option(
     "-t",

--- a/wait_for_it/wait_for_it.py
+++ b/wait_for_it/wait_for_it.py
@@ -96,7 +96,11 @@ async def _wait_until_available_and_report(reporter, host, port):
     "--service",
     metavar="host:port",
     multiple=True,
-    help="Services to test, in one of the formats 'host:port', '[v6addr]:port' or 'https://...'",
+    help="Services to test, in one of the formats "
+    "'hostname:port', "
+    "'v4addr:port', "
+    "'[v6addr]:port' or "
+    "'https://...'",
 )
 @click.argument("commands", nargs=-1)
 def cli(**kwargs):

--- a/wait_for_it/wait_for_it.py
+++ b/wait_for_it/wait_for_it.py
@@ -148,7 +148,10 @@ class _Messenger:
 
 class _ConnectionJobReporter:
     def __init__(self, host, port, timeout):
-        self._friendly_name = f"{host}:{port}"
+        host_is_an_ipv6_address = ":" in host
+        self._friendly_name = (
+            f"[{host}]:{port}" if host_is_an_ipv6_address else f"{host}:{port}"
+        )
         self._timeout = timeout
         self._started_at = None
         self.job_successful = None

--- a/wait_for_it/wait_for_it.py
+++ b/wait_for_it/wait_for_it.py
@@ -83,13 +83,6 @@ async def _wait_until_available_and_report(reporter, host, port):
     help="Test services in parallel rather than in serial",
 )
 @click.option(
-    "-s",
-    "--service",
-    metavar="host:port",
-    multiple=True,
-    help="Services to test, in one of the formats 'host:port', '[v6addr]:port' or 'https://...'",
-)
-@click.option(
     "-t",
     "--timeout",
     type=int,
@@ -97,6 +90,13 @@ async def _wait_until_available_and_report(reporter, host, port):
     default=15,
     show_default=True,
     help="Timeout in seconds, 0 for no timeout",
+)
+@click.option(
+    "-s",
+    "--service",
+    metavar="host:port",
+    multiple=True,
+    help="Services to test, in one of the formats 'host:port', '[v6addr]:port' or 'https://...'",
 )
 @click.argument("commands", nargs=-1)
 def cli(**kwargs):


### PR DESCRIPTION
## Before

```console
# wait-for-it -t 14 -s [::1]:1234
[*] Waiting 14 seconds for ::1:1234

# wait-for-it --help | tail -n2
  -s, --service host:port  Services to test, in the format host:port
  -t, --timeout seconds    Timeout in seconds, 0 for no timeout  [default: 15]
```


## After

```console
# wait-for-it -t 14 -s [::1]:1234
[*] Waiting 14 seconds for [::1]:1234

# wait-for-it --help | tail -n3
  -t, --timeout seconds    Timeout in seconds, 0 for no timeout  [default: 15]
  -s, --service host:port  Services to test, in one of the formats
                           'host:port', '[v6addr]:port' or 'https://...'
```

What do you think?