### PR TITLE
support service definition with implied host: "-s :1234"

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Options:
   -q, --quiet              Do not output any status messages
   -p, --parallel           Test services in parallel rather than in serial
   -t, --timeout seconds    Timeout in seconds, 0 for no timeout  [default: 15]
-  -s, --service host:port  Services to test, in one of the formats:
+  -s, --service host:port  Services to test, in one of the formats: ':port',
                            'hostname:port', 'v4addr:port', '[v6addr]:port' or
                            'https://...'
 ```

--- a/wait_for_it/wait_for_it.py
+++ b/wait_for_it/wait_for_it.py
@@ -97,6 +97,7 @@ async def _wait_until_available_and_report(reporter, host, port):
     metavar="host:port",
     multiple=True,
     help="Services to test, in one of the formats: "
+    "':port', "
     "'hostname:port', "
     "'v4addr:port', "
     "'[v6addr]:port' or "
@@ -152,6 +153,8 @@ class _Messenger:
 
 class _ConnectionJobReporter:
     def __init__(self, host, port, timeout):
+        if host is None:
+            host = ""
         host_is_an_ipv6_address = ":" in host
         self._friendly_name = (
             f"[{host}]:{port}" if host_is_an_ipv6_address else f"{host}:{port}"

--- a/wait_for_it/wait_for_it.py
+++ b/wait_for_it/wait_for_it.py
@@ -47,9 +47,10 @@ def _determine_host_and_port_for(service):
 
 
 async def _wait_until_available(host, port):
+    family = 0 if socket.has_ipv6 else socket.AF_INET
     while True:
         try:
-            _reader, writer = await asyncio.open_connection(host, port)
+            _reader, writer = await asyncio.open_connection(host, port, family=family)
             writer.close()
             if sys.version_info[:2] >= (3, 7):
                 await writer.wait_closed()


### PR DESCRIPTION
Allows to use `wait-for-it` as:

```bash
$ wait-for-it -s :22 -- echo "ssh is up"
[*] Waiting 15 seconds for :22
[+] :22 is available after 0 seconds
ssh is up
```