### PR TITLE
new: add support for python 3.11

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.11]
         runs-on: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.runs-on }}
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37
+envlist = py36,py37,py311
 
 [testenv]
 deps = pytest

--- a/wait_for_it/wait_for_it.py
+++ b/wait_for_it/wait_for_it.py
@@ -214,7 +214,9 @@ async def _connect_all_parallel_async(services, timeout):
             reporter.on_timeout()
 
     with _exit_on_timeout(timeout, on_exit=_report_on_all_unsuccessful_jobs):
-        await asyncio.wait(connect_job_awaitables)
+        await asyncio.wait(
+            [asyncio.ensure_future(coro) for coro in connect_job_awaitables]
+        )
 
 
 def _connect_all_parallel(services, timeout):


### PR DESCRIPTION
You get this error if you run this with python 3.11:

```
TypeError: Passing coroutines is forbidden, use tasks explicitly.
```

I guess using `.wait` on coroutines directly is no longer allowed. 