### PR TITLE
Fix crash for "wait-for-it -p echo hello"

### DIFF
--- a/wait_for_it/wait_for_it.py
+++ b/wait_for_it/wait_for_it.py
@@ -196,6 +196,9 @@ def _exit_on_timeout(timeout, on_exit):
 
 
 async def _connect_all_parallel_async(services, timeout):
+    if not services:
+        return
+
     connect_job_awaitables = []
     reporters = []
 


### PR DESCRIPTION
```console
$ wait-for-it echo hello  # serial mode
hello

$ wait-for-it -p echo hello  # parallel mode
Traceback (most recent call last):
  [..]
  File "[..]/wait_for_it/wait_for_it.py", line 218, in _connect_all_parallel_async
    [asyncio.ensure_future(coro) for coro in connect_job_awaitables]
  File "/usr/lib/python3.7/asyncio/tasks.py", line 380, in wait
    raise ValueError('Set of coroutines/Futures is empty.')
ValueError: Set of coroutines/Futures is empty.
```