### PR TITLE
Be consistent about support for Python 3.7 to 3.11

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.11]
+        python-version: [3.7, 3.11]  # oldest and most recent version supported
         runs-on: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.runs-on }}
     steps:

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,8 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: MIT License",
         "Operating System :: POSIX",
         "Topic :: Internet",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py311
+envlist = py37,py311
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
Follow-up to #49 

Please note that Python 3.8 and 3.9 are dropped from CI to save needless resources.

CC @scastlara